### PR TITLE
Crash when failed to run

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ const PercyScript = {
 
     try {
       await runFn(page, snapshot);
-    } catch (error) {
-      console.error(error);
     } finally {
       await browser.close();
     }


### PR DESCRIPTION
Before the script silently returned success when the running has failed.

Workflows that relied on PR integration with Percy had received a failure from Percy,
but independent workflows would silently pass until anyone noticed a failure.

This is breaking backwards compatibility!