### PR TITLE
Update Node Engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,21 @@ default_test_steps: &default_test_steps
     - run: yarn test
 
 jobs:
-  test_node_8:
+  test_node_10:
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:10-browsers
     environment:
       PERCY_ENABLE: 0
     <<: *default_test_steps
-  test_node_10_with_percy:
+  test_node_12_with_percy:
     # We've opted this node version to be the one that runs and reports Percy's status
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     <<: *default_test_steps
 
 workflows:
   version: 2.1
   test_and_release:
     jobs:
-      - test_node_8
-      - test_node_10_with_percy
+      - test_node_10
+      - test_node_12_with_percy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@percy/agent": "~0"
   },
   "engines": {
-    "node": ">=8.2.0"
+    "node": ">=10"
   },
   "scripts": {
     "test": "percy exec -- node ./test/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/script",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "PercyScript is the easiest way to get started with visual testing and Percy.",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Node 8 is EOL as of January 1st, 2020 and support was subsequently dropped in `@percy/agent`. This PR updates the Node engine in package.json to correctly point to Node 10.
